### PR TITLE
Bugfix: facets were not always compared in correct order

### DIFF
--- a/web/src/app/[locale]/compare/[id]/page.tsx
+++ b/web/src/app/[locale]/compare/[id]/page.tsx
@@ -66,12 +66,18 @@ export default async function ComparePage({
     })
   );
 
-  const categories = reports[0].report.results.map((result) => result.title);
+  const domains = reports[0].report.results;
+  const categories = domains.map((result) => result.title);
 
   const series = reports.map(({ name, report }) => {
     return {
       name,
-      data: report.results.map((result) => result.score)
+      data: domains.map((domain) => {
+        const match = report.results.find(
+          (r) => r.domain === domain.domain
+        );
+        return match?.score ?? 0;
+      })
     };
   });
   const getNamedFacets = (domain: string) =>


### PR DESCRIPTION
When using the compare function, it would not always compare the same facets against each other.

Person A:
<img width="1282" height="537" alt="image" src="https://github.com/user-attachments/assets/dcede3ac-1310-476a-bf4e-d6b04e6e7ffb" />

Person B:
<img width="1261" height="409" alt="image" src="https://github.com/user-attachments/assets/f198fc4f-5540-4591-b067-cbef09b2edec" />

Comparison:
<img width="1289" height="448" alt="image" src="https://github.com/user-attachments/assets/8026a58a-3e23-4838-a9ec-259b7b163220" />
